### PR TITLE
chore: add backstage entities

### DIFF
--- a/.catalog-info.yaml
+++ b/.catalog-info.yaml
@@ -1,0 +1,17 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: aurora-engine-exit-contract
+  description: |-
+    Provides functionality for exiting aurora engine
+  tags:
+    - contract
+    - aurora
+  links: []
+  annotations:
+    aurora.dev/security-tier: "1"
+spec:
+  owner: defuse-team
+  type: contract
+  lifecycle: production
+  system: defuse-protocol


### PR DESCRIPTION
## Description
PR adds a descriptor file so that our [catalog system](https://backstage.io/docs/features/software-catalog/) can add it to inventory. [Spec](https://backstage.io/docs/features/software-catalog/descriptor-format)