### PR TITLE
Update copyright owner

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Defuse
+Copyright (c) 2025 NEAR Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- update the license header to attribute copyright to NEAR Foundation for 2025

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_b_68cbd6406f40832c80feac29d099fcd5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated the license notice to reflect 2025 and NEAR Foundation. The license remains MIT with no changes to terms or wording beyond attribution.
- Chores
  - Refreshed legal metadata to ensure accurate ownership and compliance. No impact on features, functionality, or APIs; users and integrators do not need to take any action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->